### PR TITLE
Add a password prompt feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ All configuration is done in the config file in JSON format:
 * *username*/*password*: fritzbox login credentials
 * *devices*: list of device names with macs that can be used for wakeup
 
+If the password line is not present in the config file, you will be prompted for the password.
+
 #### Usage
 
 ```sh

--- a/wakeup.py
+++ b/wakeup.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import sys
+import getpass
 
 from lxml import etree
 from requests.exceptions import SSLError
@@ -41,10 +42,14 @@ def get_config(config_file):
 
 def get_sid(config):
     try:
+        password = config['password']
+    except:
+        password = getpass.getpass()
+    try:
         r = requests.get(config['url_login'], verify=config['verify_ssl'])
         t = etree.XML(r.content)
         challenge = t.xpath('//Challenge/text()')[0]
-        response = '{}-{}'.format(challenge, hashlib.md5('{}-{}'.format(challenge, config['password']).encode('utf-16-le')).hexdigest())
+        response = '{}-{}'.format(challenge, hashlib.md5('{}-{}'.format(challenge, password).encode('utf-16-le')).hexdigest())
         r = requests.get('{}?username={}&response={}'.format(config['url_login'], config['username'], response), verify=config['verify_ssl'])
         t = etree.XML(r.content)
         return t.xpath('//SID/text()')[0]


### PR DESCRIPTION
Usually it is not good practice to leave passwords lying around in plain text, therefore I added the possibility to not specify the password in the json file and prompt for the password.